### PR TITLE
Fix: Use default language when language selector is disabled

### DIFF
--- a/assets/js/translate.js
+++ b/assets/js/translate.js
@@ -7,7 +7,7 @@ function loadCurrentLanguage() {
   }
   
   // If the browser language is supported, use it, otherwise use the default language
-  if (useBrowserLangAsDefault) {
+  if (allowLanguageSelector && useBrowserLangAsDefault) {
     const browserLang = navigator.language.split('-')[0];
     return availableLanguages.includes(browserLang) ? browserLang : _defLang;
   } else {

--- a/assets/js/translate_hp.js
+++ b/assets/js/translate_hp.js
@@ -7,7 +7,7 @@ function loadCurrentLanguage() {
   }
   
   // If the browser language is supported, use it, otherwise use the default language
-  if (useBrowserLangAsDefault) {
+  if (allowLanguageSelector && useBrowserLangAsDefault) {
     const browserLang = navigator.language.split('-')[0];
     return availableLanguages.includes(browserLang) ? browserLang : _defLang;
   } else {


### PR DESCRIPTION
Fixed an issue where browser language was used even when the language selector was disabled. 
(Disabling Language Selector should disable l10n features no matter what.)